### PR TITLE
FIXED allocation size of col_mask array

### DIFF
--- a/src/munkres.cpp
+++ b/src/munkres.cpp
@@ -441,7 +441,7 @@ Munkres::solve(cv::Mat_<int> &m) {
     extendMat(mask_matrix, size, size);
     
     row_mask = new bool[size];
-    col_mask = new bool[columns];
+    col_mask = new bool[size];
     for ( unsigned int i = 0 ; i < size ; i++ ) {
         row_mask[i] = false;
     }


### PR DESCRIPTION
I've found the wrong array size allocation bug, because it caused me a debug error in visual studio just after calling delete [] col_mask;

> HEAP CORRUPTION DETECTED after normal block
> CRT detected that application wrote to memory after end of heap buffer
> I didn't make a pull request, because i downloaded it as a zip;
